### PR TITLE
Added support for specifying ds tolerations via Helm values

### DIFF
--- a/helm/templates/aws-nitro-enclaves-k8s-ds.yaml
+++ b/helm/templates/aws-nitro-enclaves-k8s-ds.yaml
@@ -49,6 +49,10 @@ spec:
       hostname: aws-nitro-enclaves-k8s-dp
       nodeSelector: {{- toYaml .Values.awsNitroEnclavesK8SDaemonset.nodeSelector | nindent
         8 }}
+      {{- if .Values.awsNitroEnclavesK8SDaemonset.tolerations }}
+      tolerations: {{- toYaml .Values.awsNitroEnclavesK8SDaemonset.tolerations | nindent 
+        8 }}
+      {{- end }}  
       priorityClassName: system-node-critical
       terminationGracePeriodSeconds: 30
       volumes:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,4 +21,5 @@ awsNitroEnclavesK8SDaemonset:
         memory: 15Mi
   nodeSelector:
     aws-nitro-enclaves-k8s-dp: enabled
+  tolerations: []
 kubernetesClusterDomain: cluster.local


### PR DESCRIPTION
Issue: https://github.com/aws/aws-nitro-enclaves-k8s-device-plugin/issues/24

### Description of changes:

This pull request adds support for pod tolerations in the Helm chart, enabling users to specify tolerations through values.yaml. This enhancement allows pods to be scheduled on nodes with matching taints, improving flexibility for workloads that require dedicated or tainted node scheduling. The deployment templates have been updated accordingly to include the tolerations configuration.

### License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
