### PR TITLE
ci: add docker-build job and optimize build script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,8 @@
 name: build
 
 on: pull_request
+permissions:
+   contents: read
 jobs:
   build:
     # this is to prevent the job to run at forked projects
@@ -24,3 +26,24 @@ jobs:
         run: go build -v ./cmd/k8s-device-plugin/k8s-device-plugin.go
       - name: Test
         run: go test -v ./...
+  docker-build:
+    # this is to prevent the job to run at forked projects
+    if: github.repository == 'aws/aws-nitro-enclaves-k8s-device-plugin'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Print image tag
+        run: |
+          cd scripts
+          bash -c 'source ./common.sh && echo "Resolved image tag: ${IMAGE}" && echo "Resolved builder image: ${BUILDER_IMAGE}"' ./common.sh
+      - name: Build container images
+        env:
+          BUILDX_CACHE: --cache-from type=gha --cache-to type=gha,mode=max
+        run: ./scripts/build_docker.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,12 @@
 name: build
 
 on: pull_request
+
+# type=gha buildx cache authenticates via ACTIONS_RUNTIME_TOKEN (Actions runtime
+# service), not GITHUB_TOKEN — cache read/write is unaffected by this block.
+# `contents: read` is sufficient for actions/checkout; no extra scopes needed.
+# Refs: https://docs.docker.com/build/cache/backends/gha/
+#       https://github.com/moby/buildkit/blob/master/cache/remotecache/gha/gha.go
 permissions:
    contents: read
 jobs:
@@ -42,7 +48,7 @@ jobs:
       - name: Print image tag
         run: |
           cd scripts
-          bash -c 'source ./common.sh && echo "Resolved image tag: ${IMAGE}" && echo "Resolved builder image: ${BUILDER_IMAGE}"' ./common.sh
+          bash -c 'source ./common.sh && echo "Resolved image tag: ${IMAGE}"'
       - name: Build container images
         env:
           BUILDX_CACHE: --cache-from type=gha --cache-to type=gha,mode=max

--- a/cmd/k8s-device-plugin/k8s-device-plugin_test.go
+++ b/cmd/k8s-device-plugin/k8s-device-plugin_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestVersionFlag builds the binary with -ldflags -X injection and runs it
+// with -version to verify the full build-time injection contract.
+func TestVersionFlag(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		buildDate string
+		wantRegex string
+	}{
+		{
+			name:      "injected release values",
+			version:   "0.4.1",
+			buildDate: "2026-04-22T17:33:56Z",
+			wantRegex: `^k8s-ne-device-plugin version 0\.4\.1 \(built: 2026-04-22T17:33:56Z\)\n$`,
+		},
+		{
+			name:      "defaults when no injection",
+			version:   "",
+			buildDate: "",
+			wantRegex: `^k8s-ne-device-plugin version dev \(built: unknown\)\n$`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			binPath := filepath.Join(t.TempDir(), "k8s-ne-device-plugin")
+
+			args := []string{"build", "-o", binPath}
+			if tc.version != "" || tc.buildDate != "" {
+				ldflags := "-X main.version=" + tc.version + " -X main.buildDate=" + tc.buildDate
+				args = append(args, "-ldflags", ldflags)
+			}
+			args = append(args, ".")
+
+			buildCmd := exec.Command("go", args...)
+			if out, err := buildCmd.CombinedOutput(); err != nil {
+				t.Fatalf("go build failed: %v\n%s", err, out)
+			}
+
+			out, err := exec.Command(binPath, "-version").CombinedOutput()
+			if err != nil {
+				t.Fatalf("running binary with -version failed: %v\n%s", err, out)
+			}
+
+			got := string(out)
+			if !regexp.MustCompile(tc.wantRegex).MatchString(got) {
+				t.Errorf("unexpected output\n got: %q\nwant regex: %q", got, tc.wantRegex)
+			}
+			if strings.Contains(got, "Starting K8s Nitro Enclaves") {
+				t.Errorf("-version output should not include startup log line, got: %q", got)
+			}
+		})
+	}
+}

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,14 +1,27 @@
 #!/bin/bash
 # Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# --load is required when using Docker BuildKit to make the image available
+# in the local image store. Override with BUILDX_LOAD="" when using engines
+# that store images locally by default (e.g. Podman).
+BUILDX_LOAD="${BUILDX_LOAD:---load}"
+
+# Optional cache directives (e.g. --cache-from type=gha --cache-to type=gha,mode=max
+# in CI, or --cache-from type=local,src=/tmp/cache locally). Empty by default.
+BUILDX_CACHE="${BUILDX_CACHE:-}"
+
 source "$(dirname $(realpath $0))/common.sh"
 
 build_docker_image() {
     local arch=$1
-    docker build --target device_plugin --platform linux/$arch -t $IMAGE-$arch $TOP_DIR -f $TOP_DIR/container/Dockerfile
+    docker buildx build $BUILDX_LOAD $BUILDX_CACHE --target device_plugin --platform linux/$arch -t $IMAGE-$arch $TOP_DIR -f $TOP_DIR/container/Dockerfile
 }
 
-docker build --target builder -t $BUILDER_IMAGE $TOP_DIR -f $TOP_DIR/container/Dockerfile ||
-    die "Failed to build generic builder image"
-arch=x86_64 && build_docker_image ${arch} || die "Failed to build ${arch} image"
-arch=aarch64 && build_docker_image ${arch} || die "Failed to build ${arch} image"
+# Build both architectures in parallel; BuildKit caches the shared builder stage.
+build_docker_image x86_64 &
+pid_x86=$!
+build_docker_image aarch64 &
+pid_arm=$!
+wait $pid_x86 || die "Failed to build x86_64 image"
+wait $pid_arm || die "Failed to build aarch64 image"

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -2,20 +2,19 @@
 # Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# --load is required when using Docker BuildKit to make the image available
-# in the local image store. Override with BUILDX_LOAD="" when using engines
-# that store images locally by default (e.g. Podman).
-BUILDX_LOAD="${BUILDX_LOAD:---load}"
-
-# Optional cache directives (e.g. --cache-from type=gha --cache-to type=gha,mode=max
-# in CI, or --cache-from type=local,src=/tmp/cache locally). Empty by default.
-BUILDX_CACHE="${BUILDX_CACHE:-}"
-
+# Build the multi-arch device plugin container images.
+#
+# Environment variables (exported by the caller, e.g. release.sh or CI):
+#   BUILDX_LOAD  Passed to `docker buildx build`. Defaults to `--load` to make
+#                the image available in the local image store. Set to empty
+#                when using engines that already store images locally (Podman).
+#   BUILDX_CACHE Optional cache directives, e.g.
+#                `--cache-from type=gha --cache-to type=gha,mode=max` in CI.
 source "$(dirname $(realpath $0))/common.sh"
 
 build_docker_image() {
     local arch=$1
-    docker buildx build $BUILDX_LOAD $BUILDX_CACHE --target device_plugin --platform linux/$arch -t $IMAGE-$arch $TOP_DIR -f $TOP_DIR/container/Dockerfile
+    docker buildx build ${BUILDX_LOAD:---load} ${BUILDX_CACHE:-} --target device_plugin --platform linux/$arch -t $IMAGE-$arch $TOP_DIR -f $TOP_DIR/container/Dockerfile
 }
 
 # Build both architectures in parallel; BuildKit caches the shared builder stage.

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -10,7 +10,6 @@ readonly TOP_DIR=$(cd $SCRIPTS_DIR/.. && pwd)
 readonly ECR_CONFIG_FILE_PATH="$SCRIPTS_DIR/.ecr.uri"
 readonly RELEASE_FILE="RELEASE"
 
-readonly BUILDER_IMAGE=ne-k8s-device-plugin-build:latest
 readonly REPOSITORY_NAME=aws-nitro-enclaves-k8s-device-plugin
 readonly RELEASE=$(cat $TOP_DIR/$RELEASE_FILE)
 readonly IMAGE=$REPOSITORY_NAME:$RELEASE

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,6 +19,14 @@ done
 source "$(dirname $(realpath $0))/common.sh"
 current_folder="$(dirname $(realpath $0))"
 
+# BuildKit flags propagated to build_docker.sh.
+#   --load     makes the built image available in the local image store so
+#              push_docker.sh can tag and push it. Override with BUILDX_LOAD=""
+#              for engines that store images locally by default (e.g. Podman).
+#   BUILDX_CACHE is optional (e.g. --cache-from type=gha --cache-to type=gha,mode=max).
+export BUILDX_LOAD="${BUILDX_LOAD:---load}"
+export BUILDX_CACHE="${BUILDX_CACHE:-}"
+
 # version of helm charts are based on /helm/Chart.yaml
 # before packaging and publishing validate that the RELEASE version, manifest.yaml
 # and helm chart version are in sync and pointig to the new multich arch docker manifest
@@ -26,6 +34,7 @@ $current_folder/validate_artifacts_versions.sh
 
 # build and upload docker artifacts
 # version for docker artifacts are based on RELEASE file
+
 $current_folder/build_docker.sh
 $current_folder/push_docker.sh
 $current_folder/create_manifest_docker.sh


### PR DESCRIPTION
- Add docker-build job with QEMU + Buildx + GHA cache
- Switch build_docker.sh to `docker buildx build` with parallel x86_64/aarch64 builds and configurable BUILDX_LOAD / BUILDX_CACHE
- Add unit test for the -version flag with ldflags injection